### PR TITLE
Updates to k8s ct-agent to make it great again

### DIFF
--- a/charts/ct-agent/Chart.yaml
+++ b/charts/ct-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ct-agent
-description: ControlTheory Agent
+description: ControlTheory Kubernetes Agent
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.1.0"

--- a/charts/ct-agent/templates/cluster_role.yaml
+++ b/charts/ct-agent/templates/cluster_role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-admin-role
+rules:
+  - verbs: ["*"]
+    resources: ["*"]
+    apiGroups: ["*"]
+  - verbs: ["*"]
+    nonResourceURLs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-admin-bind
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-admin-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/ct-agent/templates/deployment.yaml
+++ b/charts/ct-agent/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+{{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
 {{- if .Values.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret }}

--- a/charts/ct-agent/templates/pvc.yaml
+++ b/charts/ct-agent/templates/pvc.yaml
@@ -13,5 +13,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.deployment.pvc.size | default "4Gi" }}
-  storageClassName: {{ .Values.deployment.pvc.storageClass | default "persist" }}
+  storageClassName: {{ .Values.deployment.pvc.storageClass }}
 {{- end }}

--- a/charts/ct-agent/values.yaml
+++ b/charts/ct-agent/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 image:
   repository: controltheory/supervisor
   pullPolicy: Always
-  tag: latest
+  tag:  v0.121.0
 
 deployment:
   controlplane:
@@ -12,10 +12,9 @@ deployment:
     enabled: true
     accessMode: ReadWriteOnce
     size: 4Gi
-    storageClass: persist
   args:
     - --config
-    - /var/ct/config.yaml
+    - /config.yaml
 
 resources:
   enabled: true
@@ -27,7 +26,8 @@ resources:
     limit: 1Gi
 
 serviceAccount:
-  create: false
+  create: true
+  name: otel-collector-admin
 
 service:
   otelhttp:


### PR DESCRIPTION
@rbg the ct-agent Helm chart was looking for a non-existent "persist" storage class and was failing to install.

So I removed that from the pvc YAML - in general I think we should not specify a storage class by default (and thereby use whatever is already there as the default) and maybe provide an override option where user can specify optional storage class to use in Helm

I added the cluster role and binding since the Cluster receiver and K8s attribute processor both need that to talk to K8s API (like we did in daemonset one)

Updated deployment to use the service account and update values to align (changed the args to what you had in daemonset) - also pinned the image version

I tested this locally on a Kind cluster and it works (pushed the default cluster config I built to it)

